### PR TITLE
added ability for options to be a string value for terseness

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,12 @@ module.exports = Tip;
  *  - `value` defaulting to the element's title attribute
  *
  * @param {Mixed} el
- * @param {Object} options
+ * @param {Object|String} options or value
  * @api public
  */
 
 function tip(el, options) {
+  if ('string' == typeof options) options = { value : options };
   options = options || {};
   var delay = options.delay;
 

--- a/test/index.html
+++ b/test/index.html
@@ -53,6 +53,7 @@
       <a href="#" title="I'm using a title attr">Hover</a>
       <a href="#" title="I'm another link">Hover</a>
       <a href="#" id="hover-value">Hover Value</a>
+      <a href="#" id="terse-hover-value">Terse Hover Value</a>
     </div>
     <script>
       var o = require('component-jquery');
@@ -93,6 +94,8 @@
       absolute.show(25, 25).position('west');
 
       Tip('#hover-value', { delay: 1000, value: 'Hello' });
+
+      Tip('#terse-hover-value', 'Hi');
     </script>
   </body>
 </html>


### PR DESCRIPTION
My most common case is just adding a string tooltip to an element on hover without needing any options, so this makes is really nicely terse.

``` js
Tip(element, 'Tooltip value string');
```
