### PR TITLE
added fix for offset bug on 100% pages

### DIFF
--- a/tip.css
+++ b/tip.css
@@ -1,5 +1,7 @@
 .tip {
   position: absolute;
+  top: 0;
+  left: 0;
   padding: 5px;
   z-index: 1000;
 }


### PR DESCRIPTION
this is a weird case, but bear with me :)

because the tip is shown before it's new offset is calculated (obviously it has to be) there's a chance that the tip can affect the scroll height of the page, making the offset calculation wrong.

the use case where this happens is very slim, but i ran into it. if your inner `#page` or `#app` container is set to take up `100%` of the height of the `<body>`, the tooltip gets appended and adds a little bit of height to the body, causing a scrollbar where there wasn't one before. which means the left offset gets shifted slightly, so the tooltip ends up shifted to the left of its target ever so slightly. **and** it only happens the _very first time_ the tooltip is shown, because for subsequent shows it will maintain its offset from last time, and not be at the bottom of the page where it will cause an overflow. resulting in a weird, hard to track down, annoying glitch (but i finally figured out what the hell was going on haha)

the fix is simple, give it a default `top` and `left` in the base styles that put it nowhere near the bottom of the page, where it could cause a horizontal or vertical scrollbar to appear.

if needed later, they could be `-9999px` instead of `0`, but i figured `0` was nicer looking until it's a problem
