### PR TITLE
update emitter

### DIFF
--- a/component.json
+++ b/component.json
@@ -8,7 +8,7 @@
     "ui"
   ],
   "dependencies": {
-    "component/emitter": "1.0.0",
+    "component/emitter": "1.1.0",
     "component/query": "0.0.1",
     "component/events": "1.0.3",
     "component/domify": "1.0.0",


### PR DESCRIPTION
mostly because of the ie supported added in 1.0.1
