### PR TITLE
update events dependency version to 1.0.4

### DIFF
--- a/component.json
+++ b/component.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "component/emitter": "1.1.0",
     "component/query": "0.0.1",
-    "component/events": "1.0.3",
+    "component/events": "1.0.4",
     "component/domify": "1.0.0",
     "component/classes": "1.1.2",
     "component/css": "*",


### PR DESCRIPTION
events 1.0.4 has error handling on the `.unbind()` method, unlike 1.0.3. With 1.0.3 we are throwing when calling `.hide()` with a pixel-positioned tip. (Since no events are bound when using that) Just updating the dep fixes this bug.
