### PR TITLE
add tip.attach(el) to API documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,6 +80,10 @@ Options:
 ### Tip#hide([ms])
 
   Hide the tip immediately or wait `ms`.
+  
+### Tip#attach(el)
+  
+  Attach the tip to the given `el`, showing on `mouseover` and hiding on `mouseout`.
 
 ### Tip#effect(name)
 


### PR DESCRIPTION
this is a super common use case, doesn't make sense to make the user dig into the code to find out how to do it.
