### PR TITLE
Bump `component/events` at `1.0.5`

### DIFF
--- a/component.json
+++ b/component.json
@@ -11,7 +11,7 @@
     "component/bind": "*",
     "component/emitter": "1.1.0",
     "component/query": "0.0.1",
-    "component/events": "1.0.4",
+    "component/events": "1.0.5",
     "component/domify": "1.0.0",
     "component/classes": "1.1.2",
     "component/css": "*",


### PR DESCRIPTION
`component/events@1.0.5` solves a huge and horrible delegation bug introducing `discore/closest` to the matching logic.

As I explain at component/events#9, this update would help avoid a randomly (and difficult to sort) installation issue of that dependency.
