### PR TITLE
Unbinding window events when cancelling hide

### DIFF
--- a/index.js
+++ b/index.js
@@ -363,6 +363,8 @@ Tip.prototype.offset = function(pos){
  */
 
 Tip.prototype.cancelHide = function(){
+  this.winEvents.unbind('resize', 'reposition');
+  this.winEvents.unbind('scroll', 'reposition');
   clearTimeout(this._hide);
 };
 


### PR DESCRIPTION
Currently, the window events can be bound multiple times in some cases. If the hide is cancelled,
then show is called again (ie: mouseover/out fun times) the winEvents simply get bound again,
causing the previous handler to be forever bound (since unbind only gets the last one in the stack
apparently, probably needs to be addressed in component/events somehow)

This could probably be addressed more completely by using mouseenter/leave instead of mouseover/out,
but that is not addressed in this commit.
