### PR TITLE
improve binding of 'scroll' and 'resize' handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,6 @@ function Tip(content, options) {
   this.delay = options.delay || 300;
   this.el = html.cloneNode(true);
   this.events = events(this.el, this);
-  this.winEvents = events(window, this);
   this.classes = classes(this.el);
   this.inner = query('.tip-inner', this.el);
   this.message(content);
@@ -220,8 +219,11 @@ Tip.prototype.show = function(el){
   this.reposition();
   this.emit('show', this.target);
 
-  this.winEvents.bind('resize', 'reposition');
-  this.winEvents.bind('scroll', 'reposition');
+  if (!this.winEvents) {
+    this.winEvents = events(window, this);
+    this.winEvents.bind('resize', 'reposition');
+    this.winEvents.bind('scroll', 'reposition');
+  }
 
   return this;
 };
@@ -404,8 +406,10 @@ Tip.prototype.hide = function(ms){
  */
 
 Tip.prototype.remove = function(){
-  this.winEvents.unbind('resize', 'reposition');
-  this.winEvents.unbind('scroll', 'reposition');
+  if (this.winEvents) {
+    this.winEvents.unbind();
+    this.winEvents = null;
+  }
   this.emit('hide');
 
   var parent = this.el.parentNode;

--- a/test/index.html
+++ b/test/index.html
@@ -42,11 +42,17 @@
       #border {
         border-width: 10px;
       }
+      .hide-tip {
+        margin-left: 4em;
+      }
     </style>
   </head>
   <body>
     <title>Tip</title>
     <script src="../build/build.js"></script>
+    <div>
+      <button class="hide-tip">Hide tip</button>
+    </div>
     <div id="links">
       <a href="#" id="top">Top</a>
       <a href="#" id="bottom">Bottom</a>
@@ -112,6 +118,9 @@
 
       var absolute = new Tip('(25, 25)');
       absolute.show(25, 25).position('right');
+      events.bind(q('.hide-tip'), 'click', function() {
+        absolute.hide();
+      });
 
       Tip('#hover-value', { delay: 1000, value: 'Hello' });
 


### PR DESCRIPTION
ensure that 'scroll' and 'resize' handlers are in all cases bound at most once, and that they are always unbound when Tip is removed

fixes #38
fixes #25
