### PR TITLE
accept element for content, add 'hiding' event

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,13 +75,14 @@ Emitter(Tip.prototype);
 /**
  * Set tip `content`.
  *
- * @param {String|jQuery|Element} content
+ * @param {String|Element} content
  * @return {Tip} self
  * @api public
  */
 
 Tip.prototype.message = function(content){
-  this.inner.innerHTML = content;
+  if ('string' == typeof content) content = domify(content);
+  this.inner.appendChild(content);
   return this;
 };
 
@@ -95,7 +96,6 @@ Tip.prototype.message = function(content){
  */
 
 Tip.prototype.attach = function(el){
-  var self = this;
   this.target = el;
   this.handleEvents = events(el, this);
   this.handleEvents.bind('mouseover');


### PR DESCRIPTION
just a couple of things I needed. The docs suggested that elements could be accepted as content. This pr allows this. I've also added a 'hiding' event that occurs before the element is actually removed. Useful when using 'fade', for example, which only fires the 'hide' event after 300ms.

oh, and i deleted an unused 'self' var.
