### PR TITLE
Small change to allow using cssjanus with tip for RTL support.

### DIFF
--- a/tip.css
+++ b/tip.css
@@ -4,6 +4,7 @@
   z-index: 1000;
   /* default offset for edge-cases: https://github.com/component/tip/pull/12 */
   top: 0;
+  /* @noflip */
   left: 0;
 }
 


### PR DESCRIPTION
I'm working on a project where [cssjanus](https://github.com/cssjanus/cssjanus) is utilized to add RTL support.  Unfortunately the default left offset is converted to `right` by cssjanus and makes tips go to `right: 0`.  Small fix adds a css comment which prevents cssjanus from altering the default left offset.
